### PR TITLE
Update untuk Versi 1.3.1

### DIFF
--- a/Template Artikel Ilmiah/Simple/main.tex
+++ b/Template Artikel Ilmiah/Simple/main.tex
@@ -1,7 +1,7 @@
 % !TEX program = lualatex
 
 % Template Artikel Ilmiah
-% Versi 1.3.0
+% Versi 1.3.1
 
 %==========%
 % PREAMBLE %
@@ -143,6 +143,47 @@
     ndkeywordstyle=\itshape\bfseries\color{monokai-orange},
     stringstyle=\color{monokai-green},
     identifierstyle=\color{black},
+}
+
+%==========%
+% TEXT BOX %
+%==========%
+
+\usepackage[most]{tcolorbox}
+
+% Block Quote
+\newtcolorbox{blockquote}{
+    parbox=false,
+    boxrule=0pt,
+    frame hidden,
+    colback=gray!3,
+    enhanced,
+    sharp corners,
+    borderline west={2pt}{0pt}{black}
+}
+
+% Block Quote Indent
+\newtcolorbox{indentbquote}{
+    size=minimal,
+    parbox=false,
+    boxrule=0pt,
+    frame hidden,
+    colback=gray!3,
+    enhanced,
+    sharp corners,
+    left=1.24cm,
+    right=1.24cm,
+    top=10pt,
+    bottom=10pt,
+    borderline west={2pt}{0pt}{black}
+}
+
+% Text Box
+\newtcolorbox{textbox}{
+    parbox=false,
+    sharp corners,
+    colback=white,
+    boxrule=1pt
 }
 
 %============================%

--- a/Template Artikel Ilmiah/With Example/main.tex
+++ b/Template Artikel Ilmiah/With Example/main.tex
@@ -1,7 +1,7 @@
 % !TEX program = lualatex
 
 % Template Artikel Ilmiah
-% Versi 1.3.0
+% Versi 1.3.1
 
 %==========%
 % PREAMBLE %
@@ -143,6 +143,47 @@
     ndkeywordstyle=\itshape\bfseries\color{monokai-orange},
     stringstyle=\color{monokai-green},
     identifierstyle=\color{black},
+}
+
+%==========%
+% TEXT BOX %
+%==========%
+
+\usepackage[most]{tcolorbox}
+
+% Block Quote
+\newtcolorbox{blockquote}{
+    parbox=false,
+    boxrule=0pt,
+    frame hidden,
+    colback=gray!3,
+    enhanced,
+    sharp corners,
+    borderline west={2pt}{0pt}{black}
+}
+
+% Block Quote Indent
+\newtcolorbox{indentbquote}{
+    size=minimal,
+    parbox=false,
+    boxrule=0pt,
+    frame hidden,
+    colback=gray!3,
+    enhanced,
+    sharp corners,
+    left=1.24cm,
+    right=1.24cm,
+    top=10pt,
+    bottom=10pt,
+    borderline west={2pt}{0pt}{black}
+}
+
+% Text Box
+\newtcolorbox{textbox}{
+    parbox=false,
+    sharp corners,
+    colback=white,
+    boxrule=1pt
 }
 
 %============================%

--- a/Template Artikel/Rewritten Showcase/main.tex
+++ b/Template Artikel/Rewritten Showcase/main.tex
@@ -1,7 +1,7 @@
 % !TEX program = lualatex
 
 % Template Artikel Tugas Tutorial
-% Versi 1.3.0
+% Versi 1.3.1
 
 %   /‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾/
 %  /   INFORMASI KARYA TULIS   /
@@ -208,6 +208,47 @@
     ndkeywordstyle=\itshape\bfseries\color{monokai-orange},
     stringstyle=\color{monokai-green},
     identifierstyle=\color{black},
+}
+
+%==========%
+% TEXT BOX %
+%==========%
+
+\usepackage[most]{tcolorbox}
+
+% Block Quote
+\newtcolorbox{blockquote}{
+    parbox=false,
+    boxrule=0pt,
+    frame hidden,
+    colback=gray!3,
+    enhanced,
+    sharp corners,
+    borderline west={2pt}{0pt}{black}
+}
+
+% Block Quote Indent
+\newtcolorbox{indentbquote}{
+    size=minimal,
+    parbox=false,
+    boxrule=0pt,
+    frame hidden,
+    colback=gray!3,
+    enhanced,
+    sharp corners,
+    left=1.24cm,
+    right=1.24cm,
+    top=10pt,
+    bottom=10pt,
+    borderline west={2pt}{0pt}{black}
+}
+
+% Text Box
+\newtcolorbox{textbox}{
+    parbox=false,
+    sharp corners,
+    colback=white,
+    boxrule=1pt
 }
 
 %============================%

--- a/Template Artikel/Simple/main.tex
+++ b/Template Artikel/Simple/main.tex
@@ -1,7 +1,7 @@
 % !TEX program = lualatex
 
 % Template Artikel Tugas Tutorial
-% Versi 1.3.0
+% Versi 1.3.1
 
 %==========%
 % PREAMBLE %
@@ -143,6 +143,47 @@
     ndkeywordstyle=\itshape\bfseries\color{monokai-orange},
     stringstyle=\color{monokai-green},
     identifierstyle=\color{black},
+}
+
+%==========%
+% TEXT BOX %
+%==========%
+
+\usepackage[most]{tcolorbox}
+
+% Block Quote
+\newtcolorbox{blockquote}{
+    parbox=false,
+    boxrule=0pt,
+    frame hidden,
+    colback=gray!3,
+    enhanced,
+    sharp corners,
+    borderline west={2pt}{0pt}{black}
+}
+
+% Block Quote Indent
+\newtcolorbox{indentbquote}{
+    size=minimal,
+    parbox=false,
+    boxrule=0pt,
+    frame hidden,
+    colback=gray!3,
+    enhanced,
+    sharp corners,
+    left=1.24cm,
+    right=1.24cm,
+    top=10pt,
+    bottom=10pt,
+    borderline west={2pt}{0pt}{black}
+}
+
+% Text Box
+\newtcolorbox{textbox}{
+    parbox=false,
+    sharp corners,
+    colback=white,
+    boxrule=1pt
 }
 
 %============================%

--- a/Template Artikel/With Example/main.tex
+++ b/Template Artikel/With Example/main.tex
@@ -1,7 +1,7 @@
 % !TEX program = lualatex
 
 % Template Artikel Tugas Tutorial
-% Versi 1.3.0
+% Versi 1.3.1
 
 %==========%
 % PREAMBLE %
@@ -143,6 +143,47 @@
     ndkeywordstyle=\itshape\bfseries\color{monokai-orange},
     stringstyle=\color{monokai-green},
     identifierstyle=\color{black},
+}
+
+%==========%
+% TEXT BOX %
+%==========%
+
+\usepackage[most]{tcolorbox}
+
+% Block Quote
+\newtcolorbox{blockquote}{
+    parbox=false,
+    boxrule=0pt,
+    frame hidden,
+    colback=gray!3,
+    enhanced,
+    sharp corners,
+    borderline west={2pt}{0pt}{black}
+}
+
+% Block Quote Indent
+\newtcolorbox{indentbquote}{
+    size=minimal,
+    parbox=false,
+    boxrule=0pt,
+    frame hidden,
+    colback=gray!3,
+    enhanced,
+    sharp corners,
+    left=1.24cm,
+    right=1.24cm,
+    top=10pt,
+    bottom=10pt,
+    borderline west={2pt}{0pt}{black}
+}
+
+% Text Box
+\newtcolorbox{textbox}{
+    parbox=false,
+    sharp corners,
+    colback=white,
+    boxrule=1pt
 }
 
 %============================%

--- a/Template Diskusi Tuton/Rewritten Showcase/main.tex
+++ b/Template Diskusi Tuton/Rewritten Showcase/main.tex
@@ -1,7 +1,7 @@
 % !TEX program = lualatex
 
 % Template Lembar Jawaban Diskusi Tutorial
-% Versi 1.3.0
+% Versi 1.3.1
 
 %   /‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾/
 %  /   INFORMASI KARYA TULIS   /
@@ -164,6 +164,47 @@
     ndkeywordstyle=\itshape\bfseries\color{monokai-orange},
     stringstyle=\color{monokai-green},
     identifierstyle=\color{black},
+}
+
+%==========%
+% TEXT BOX %
+%==========%
+
+\usepackage[most]{tcolorbox}
+
+% Block Quote
+\newtcolorbox{blockquote}{
+    parbox=false,
+    boxrule=0pt,
+    frame hidden,
+    colback=gray!3,
+    enhanced,
+    sharp corners,
+    borderline west={2pt}{0pt}{black}
+}
+
+% Block Quote Indent
+\newtcolorbox{indentbquote}{
+    size=minimal,
+    parbox=false,
+    boxrule=0pt,
+    frame hidden,
+    colback=gray!3,
+    enhanced,
+    sharp corners,
+    left=1.24cm,
+    right=1.24cm,
+    top=10pt,
+    bottom=10pt,
+    borderline west={2pt}{0pt}{black}
+}
+
+% Text Box
+\newtcolorbox{textbox}{
+    parbox=false,
+    sharp corners,
+    colback=white,
+    boxrule=1pt
 }
 
 %============================%

--- a/Template Diskusi Tuton/Simple/main.tex
+++ b/Template Diskusi Tuton/Simple/main.tex
@@ -1,7 +1,7 @@
 % !TEX program = lualatex
 
 % Template Lembar Jawaban Diskusi Tutorial
-% Versi 1.3.0
+% Versi 1.3.1
 
 %==========%
 % PREAMBLE %
@@ -143,6 +143,47 @@
     ndkeywordstyle=\itshape\bfseries\color{monokai-orange},
     stringstyle=\color{monokai-green},
     identifierstyle=\color{black},
+}
+
+%==========%
+% TEXT BOX %
+%==========%
+
+\usepackage[most]{tcolorbox}
+
+% Block Quote
+\newtcolorbox{blockquote}{
+    parbox=false,
+    boxrule=0pt,
+    frame hidden,
+    colback=gray!3,
+    enhanced,
+    sharp corners,
+    borderline west={2pt}{0pt}{black}
+}
+
+% Block Quote Indent
+\newtcolorbox{indentbquote}{
+    size=minimal,
+    parbox=false,
+    boxrule=0pt,
+    frame hidden,
+    colback=gray!3,
+    enhanced,
+    sharp corners,
+    left=1.24cm,
+    right=1.24cm,
+    top=10pt,
+    bottom=10pt,
+    borderline west={2pt}{0pt}{black}
+}
+
+% Text Box
+\newtcolorbox{textbox}{
+    parbox=false,
+    sharp corners,
+    colback=white,
+    boxrule=1pt
 }
 
 %============================%

--- a/Template Diskusi Tuton/With Example/main.tex
+++ b/Template Diskusi Tuton/With Example/main.tex
@@ -1,7 +1,7 @@
 % !TEX program = lualatex
 
 % Template Lembar Jawaban Diskusi Tutorial
-% Versi 1.3.0
+% Versi 1.3.1
 
 %==========%
 % PREAMBLE %
@@ -143,6 +143,47 @@
     ndkeywordstyle=\itshape\bfseries\color{monokai-orange},
     stringstyle=\color{monokai-green},
     identifierstyle=\color{black},
+}
+
+%==========%
+% TEXT BOX %
+%==========%
+
+\usepackage[most]{tcolorbox}
+
+% Block Quote
+\newtcolorbox{blockquote}{
+    parbox=false,
+    boxrule=0pt,
+    frame hidden,
+    colback=gray!3,
+    enhanced,
+    sharp corners,
+    borderline west={2pt}{0pt}{black}
+}
+
+% Block Quote Indent
+\newtcolorbox{indentbquote}{
+    size=minimal,
+    parbox=false,
+    boxrule=0pt,
+    frame hidden,
+    colback=gray!3,
+    enhanced,
+    sharp corners,
+    left=1.24cm,
+    right=1.24cm,
+    top=10pt,
+    bottom=10pt,
+    borderline west={2pt}{0pt}{black}
+}
+
+% Text Box
+\newtcolorbox{textbox}{
+    parbox=false,
+    sharp corners,
+    colback=white,
+    boxrule=1pt
 }
 
 %============================%

--- a/Template Makalah/Rewritten Showcase/main.tex
+++ b/Template Makalah/Rewritten Showcase/main.tex
@@ -1,7 +1,7 @@
 % !TEX program = lualatex
 
 % Template Makalah Tugas Tutorial [Rewritten Showcase]
-% Versi 1.3.0
+% Versi 1.3.1
 
 %   /‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾/
 %  /   INFORMASI KARYA TULIS   /
@@ -190,6 +190,47 @@
     ndkeywordstyle=\itshape\bfseries\color{monokai-orange},
     stringstyle=\color{monokai-green},
     identifierstyle=\color{black},
+}
+
+%==========%
+% TEXT BOX %
+%==========%
+
+\usepackage[most]{tcolorbox}
+
+% Block Quote
+\newtcolorbox{blockquote}{
+    parbox=false,
+    boxrule=0pt,
+    frame hidden,
+    colback=gray!3,
+    enhanced,
+    sharp corners,
+    borderline west={2pt}{0pt}{black}
+}
+
+% Block Quote Indent
+\newtcolorbox{indentbquote}{
+    size=minimal,
+    parbox=false,
+    boxrule=0pt,
+    frame hidden,
+    colback=gray!3,
+    enhanced,
+    sharp corners,
+    left=1.24cm,
+    right=1.24cm,
+    top=10pt,
+    bottom=10pt,
+    borderline west={2pt}{0pt}{black}
+}
+
+% Text Box
+\newtcolorbox{textbox}{
+    parbox=false,
+    sharp corners,
+    colback=white,
+    boxrule=1pt
 }
 
 %============================%

--- a/Template Makalah/Simple/main.tex
+++ b/Template Makalah/Simple/main.tex
@@ -1,7 +1,7 @@
 % !TEX program = lualatex
 
 % Template Makalah Tugas Tutorial
-% Versi 1.3.0
+% Versi 1.3.1
 
 %==========%
 % PREAMBLE %
@@ -143,6 +143,47 @@
     ndkeywordstyle=\itshape\bfseries\color{monokai-orange},
     stringstyle=\color{monokai-green},
     identifierstyle=\color{black},
+}
+
+%==========%
+% TEXT BOX %
+%==========%
+
+\usepackage[most]{tcolorbox}
+
+% Block Quote
+\newtcolorbox{blockquote}{
+    parbox=false,
+    boxrule=0pt,
+    frame hidden,
+    colback=gray!3,
+    enhanced,
+    sharp corners,
+    borderline west={2pt}{0pt}{black}
+}
+
+% Block Quote Indent
+\newtcolorbox{indentbquote}{
+    size=minimal,
+    parbox=false,
+    boxrule=0pt,
+    frame hidden,
+    colback=gray!3,
+    enhanced,
+    sharp corners,
+    left=1.24cm,
+    right=1.24cm,
+    top=10pt,
+    bottom=10pt,
+    borderline west={2pt}{0pt}{black}
+}
+
+% Text Box
+\newtcolorbox{textbox}{
+    parbox=false,
+    sharp corners,
+    colback=white,
+    boxrule=1pt
 }
 
 %============================%

--- a/Template Makalah/With Example/main.tex
+++ b/Template Makalah/With Example/main.tex
@@ -1,7 +1,7 @@
 % !TEX program = lualatex
 
 % Template Makalah Tugas Tutorial
-% Versi 1.3.0
+% Versi 1.3.1
 
 %==========%
 % PREAMBLE %
@@ -143,6 +143,47 @@
     ndkeywordstyle=\itshape\bfseries\color{monokai-orange},
     stringstyle=\color{monokai-green},
     identifierstyle=\color{black},
+}
+
+%==========%
+% TEXT BOX %
+%==========%
+
+\usepackage[most]{tcolorbox}
+
+% Block Quote
+\newtcolorbox{blockquote}{
+    parbox=false,
+    boxrule=0pt,
+    frame hidden,
+    colback=gray!3,
+    enhanced,
+    sharp corners,
+    borderline west={2pt}{0pt}{black}
+}
+
+% Block Quote Indent
+\newtcolorbox{indentbquote}{
+    size=minimal,
+    parbox=false,
+    boxrule=0pt,
+    frame hidden,
+    colback=gray!3,
+    enhanced,
+    sharp corners,
+    left=1.24cm,
+    right=1.24cm,
+    top=10pt,
+    bottom=10pt,
+    borderline west={2pt}{0pt}{black}
+}
+
+% Text Box
+\newtcolorbox{textbox}{
+    parbox=false,
+    sharp corners,
+    colback=white,
+    boxrule=1pt
 }
 
 %============================%

--- a/Template Tugas Tuton/Rewritten Showcase/main.tex
+++ b/Template Tugas Tuton/Rewritten Showcase/main.tex
@@ -1,7 +1,7 @@
 % !TEX program = lualatex
 
 % Template Tugas Tutorial [Rewritten Showcase]
-% Versi 1.3.0
+% Versi 1.3.1
 
 %   /‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾/
 %  /   INFORMASI KARYA TULIS   /
@@ -165,6 +165,47 @@
     ndkeywordstyle=\itshape\bfseries\color{monokai-orange},
     stringstyle=\color{monokai-green},
     identifierstyle=\color{black},
+}
+
+%==========%
+% TEXT BOX %
+%==========%
+
+\usepackage[most]{tcolorbox}
+
+% Block Quote
+\newtcolorbox{blockquote}{
+    parbox=false,
+    boxrule=0pt,
+    frame hidden,
+    colback=gray!3,
+    enhanced,
+    sharp corners,
+    borderline west={2pt}{0pt}{black}
+}
+
+% Block Quote Indent
+\newtcolorbox{indentbquote}{
+    size=minimal,
+    parbox=false,
+    boxrule=0pt,
+    frame hidden,
+    colback=gray!3,
+    enhanced,
+    sharp corners,
+    left=1.24cm,
+    right=1.24cm,
+    top=10pt,
+    bottom=10pt,
+    borderline west={2pt}{0pt}{black}
+}
+
+% Text Box
+\newtcolorbox{textbox}{
+    parbox=false,
+    sharp corners,
+    colback=white,
+    boxrule=1pt
 }
 
 %============================%

--- a/Template Tugas Tuton/Rewritten Showcase/preset/APA-bahasa-campuran.tex
+++ b/Template Tugas Tuton/Rewritten Showcase/preset/APA-bahasa-campuran.tex
@@ -20,30 +20,16 @@
 \renewcommand{\bibprogramminglanguage}{Bahasa pemrograman}%
 %%
 %% Other labels
-\renewcommand{\bibnodate}{t.t.\hbox{}}%   % ``tanpa tanggal''
 \renewcommand{\BIP}{dalam proses terbit}%            % ``in press''
-\renewcommand{\BOthers}[1]{et al.\hbox{}}% ``dan lain-lain''
-\renewcommand{\BOthersPeriod}[1]{et al.\hbox{}}% ``dan lain-lain'' dengan titik
 \renewcommand{\BIn}{Dalam}%                  % for ``In '' editor...
 \renewcommand{\Bby}{oleh}%                  % for ``by '' editor... (in reprints)
-\renewcommand{\BED}{Penyunt.}%          % penyunting
-\renewcommand{\BEDS}{Penyunt.}%        % para penyunting
-\renewcommand{\BTRANS}{Penerj.}%    % penerjemah
-\renewcommand{\BTRANSS}{Penerj.}%   % para penerjemah
-\renewcommand{\BTRANSL}{terj.}%   % terjemahan, for the year field
 \renewcommand{\BCHAIR}{Ketua}%            % ketua simposium
 \renewcommand{\BCHAIRS}{Para Ketua}%          % para ketua
 \renewcommand{\BVOL}{Jilid}%        % jilid
 \renewcommand{\BVOLS}{Jilid}%        % jilid
-\renewcommand{\BNUM}{No.\hbox{}}%         % nomor
-\renewcommand{\BNUMS}{No.\hbox{}}%       % nomor
-\renewcommand{\BEd}{ed.\hbox{}}%          % edisi
 \renewcommand{\BCHAP}{bab}%        % bab
 \renewcommand{\BCHAPS}{bab}%       % bab
-\renewcommand{\BPG}{h.\hbox{}}%           % halaman
-\renewcommand{\BPGS}{hlm.\hbox{}}%         % halaman
-%% Default technical report type name.
-\renewcommand{\BTR}{Lap. Tek.}
+
 %% Default PhD thesis type name.
 \renewcommand{\BPhD}{Disertasi doktor}
 %% Default unpublished PhD thesis type name.

--- a/Template Tugas Tuton/Simple/main.tex
+++ b/Template Tugas Tuton/Simple/main.tex
@@ -1,7 +1,7 @@
 % !TEX program = lualatex
 
 % Template Tugas Tutorial
-% Versi 1.3.0
+% Versi 1.3.1
 
 %==========%
 % PREAMBLE %
@@ -143,6 +143,47 @@
     ndkeywordstyle=\itshape\bfseries\color{monokai-orange},
     stringstyle=\color{monokai-green},
     identifierstyle=\color{black},
+}
+
+%==========%
+% TEXT BOX %
+%==========%
+
+\usepackage[most]{tcolorbox}
+
+% Block Quote
+\newtcolorbox{blockquote}{
+    parbox=false,
+    boxrule=0pt,
+    frame hidden,
+    colback=gray!3,
+    enhanced,
+    sharp corners,
+    borderline west={2pt}{0pt}{black}
+}
+
+% Block Quote Indent
+\newtcolorbox{indentbquote}{
+    size=minimal,
+    parbox=false,
+    boxrule=0pt,
+    frame hidden,
+    colback=gray!3,
+    enhanced,
+    sharp corners,
+    left=1.24cm,
+    right=1.24cm,
+    top=10pt,
+    bottom=10pt,
+    borderline west={2pt}{0pt}{black}
+}
+
+% Text Box
+\newtcolorbox{textbox}{
+    parbox=false,
+    sharp corners,
+    colback=white,
+    boxrule=1pt
 }
 
 %============================%

--- a/Template Tugas Tuton/Simple/preset/APA-bahasa-campuran.tex
+++ b/Template Tugas Tuton/Simple/preset/APA-bahasa-campuran.tex
@@ -20,30 +20,16 @@
 \renewcommand{\bibprogramminglanguage}{Bahasa pemrograman}%
 %%
 %% Other labels
-\renewcommand{\bibnodate}{t.t.\hbox{}}%   % ``tanpa tanggal''
 \renewcommand{\BIP}{dalam proses terbit}%            % ``in press''
-\renewcommand{\BOthers}[1]{et al.\hbox{}}% ``dan lain-lain''
-\renewcommand{\BOthersPeriod}[1]{et al.\hbox{}}% ``dan lain-lain'' dengan titik
 \renewcommand{\BIn}{Dalam}%                  % for ``In '' editor...
 \renewcommand{\Bby}{oleh}%                  % for ``by '' editor... (in reprints)
-\renewcommand{\BED}{Penyunt.}%          % penyunting
-\renewcommand{\BEDS}{Penyunt.}%        % para penyunting
-\renewcommand{\BTRANS}{Penerj.}%    % penerjemah
-\renewcommand{\BTRANSS}{Penerj.}%   % para penerjemah
-\renewcommand{\BTRANSL}{terj.}%   % terjemahan, for the year field
 \renewcommand{\BCHAIR}{Ketua}%            % ketua simposium
 \renewcommand{\BCHAIRS}{Para Ketua}%          % para ketua
 \renewcommand{\BVOL}{Jilid}%        % jilid
 \renewcommand{\BVOLS}{Jilid}%        % jilid
-\renewcommand{\BNUM}{No.\hbox{}}%         % nomor
-\renewcommand{\BNUMS}{No.\hbox{}}%       % nomor
-\renewcommand{\BEd}{ed.\hbox{}}%          % edisi
 \renewcommand{\BCHAP}{bab}%        % bab
 \renewcommand{\BCHAPS}{bab}%       % bab
-\renewcommand{\BPG}{h.\hbox{}}%           % halaman
-\renewcommand{\BPGS}{hlm.\hbox{}}%         % halaman
-%% Default technical report type name.
-\renewcommand{\BTR}{Lap. Tek.}
+
 %% Default PhD thesis type name.
 \renewcommand{\BPhD}{Disertasi doktor}
 %% Default unpublished PhD thesis type name.

--- a/Template Tugas Tuton/With Example/main.tex
+++ b/Template Tugas Tuton/With Example/main.tex
@@ -1,7 +1,7 @@
 % !TEX program = lualatex
 
 % Template Tugas Tutorial
-% Versi 1.3.0
+% Versi 1.3.1
 
 %==========%
 % PREAMBLE %
@@ -143,6 +143,47 @@
     ndkeywordstyle=\itshape\bfseries\color{monokai-orange},
     stringstyle=\color{monokai-green},
     identifierstyle=\color{black},
+}
+
+%==========%
+% TEXT BOX %
+%==========%
+
+\usepackage[most]{tcolorbox}
+
+% Block Quote
+\newtcolorbox{blockquote}{
+    parbox=false,
+    boxrule=0pt,
+    frame hidden,
+    colback=gray!3,
+    enhanced,
+    sharp corners,
+    borderline west={2pt}{0pt}{black}
+}
+
+% Block Quote Indent
+\newtcolorbox{indentbquote}{
+    size=minimal,
+    parbox=false,
+    boxrule=0pt,
+    frame hidden,
+    colback=gray!3,
+    enhanced,
+    sharp corners,
+    left=1.24cm,
+    right=1.24cm,
+    top=10pt,
+    bottom=10pt,
+    borderline west={2pt}{0pt}{black}
+}
+
+% Text Box
+\newtcolorbox{textbox}{
+    parbox=false,
+    sharp corners,
+    colback=white,
+    boxrule=1pt
 }
 
 %============================%

--- a/Template Tugas Tuton/With Example/preset/APA-bahasa-campuran.tex
+++ b/Template Tugas Tuton/With Example/preset/APA-bahasa-campuran.tex
@@ -20,30 +20,16 @@
 \renewcommand{\bibprogramminglanguage}{Bahasa pemrograman}%
 %%
 %% Other labels
-\renewcommand{\bibnodate}{t.t.\hbox{}}%   % ``tanpa tanggal''
 \renewcommand{\BIP}{dalam proses terbit}%            % ``in press''
-\renewcommand{\BOthers}[1]{et al.\hbox{}}% ``dan lain-lain''
-\renewcommand{\BOthersPeriod}[1]{et al.\hbox{}}% ``dan lain-lain'' dengan titik
 \renewcommand{\BIn}{Dalam}%                  % for ``In '' editor...
 \renewcommand{\Bby}{oleh}%                  % for ``by '' editor... (in reprints)
-\renewcommand{\BED}{Penyunt.}%          % penyunting
-\renewcommand{\BEDS}{Penyunt.}%        % para penyunting
-\renewcommand{\BTRANS}{Penerj.}%    % penerjemah
-\renewcommand{\BTRANSS}{Penerj.}%   % para penerjemah
-\renewcommand{\BTRANSL}{terj.}%   % terjemahan, for the year field
 \renewcommand{\BCHAIR}{Ketua}%            % ketua simposium
 \renewcommand{\BCHAIRS}{Para Ketua}%          % para ketua
 \renewcommand{\BVOL}{Jilid}%        % jilid
 \renewcommand{\BVOLS}{Jilid}%        % jilid
-\renewcommand{\BNUM}{No.\hbox{}}%         % nomor
-\renewcommand{\BNUMS}{No.\hbox{}}%       % nomor
-\renewcommand{\BEd}{ed.\hbox{}}%          % edisi
 \renewcommand{\BCHAP}{bab}%        % bab
 \renewcommand{\BCHAPS}{bab}%       % bab
-\renewcommand{\BPG}{h.\hbox{}}%           % halaman
-\renewcommand{\BPGS}{hlm.\hbox{}}%         % halaman
-%% Default technical report type name.
-\renewcommand{\BTR}{Lap. Tek.}
+
 %% Default PhD thesis type name.
 \renewcommand{\BPhD}{Disertasi doktor}
 %% Default unpublished PhD thesis type name.


### PR DESCRIPTION
### Markdown-Style Blockquote dan Textbox

> [!NOTE]
> Hanya merupakan fitur tambahan untuk memperkaya tampilan kutipan/quote di dokumen, sama juga dengan textbox yang dapat dipakai jika diperlukan.

Penambahan fitur blockquote dengan style markdown menggunakan `tcolorbox`

> Seperti ini

Disediakan dua jenis blockquote berupa environment `blockquote` (normal) dan `indentbquote` (dengan paragraf yang lebih menjorok 1,24cm)

Selain blockquote, ada juga textbox yang dapat digunakan dengan environment `textbox`.

### Fixes

#### Penerjemahan di Bahasa Campuran

Template Tugas Tuton mulanya memiliki file `APA-bahasa-campuran.tex` yang malah menerjemahkan istilah dan singkatannya. Sekarang sudah di-fix sehingga singkatan tidak akan diterjemahkan lagi.